### PR TITLE
feat(jobs): Add the build base image job

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,25 @@
 FROM jenkins/jenkins:lts-alpine
 
+COPY images images
+
 COPY jenkins/jenkins.yml jenkins/jenkins.yml
 
 COPY jenkins/plugins.yml jenkins/plugins.yml
 
+COPY jenkins/job_dsl.groovy jenkins/job_dsl.groovy
+
 COPY .env .env
 
 COPY agent.jar agent.jar
+
+COPY --from=docker:20.10.11 /usr/local/bin/docker /usr/bin/
+
+ENV DOCKER_HOST unix:///var/run/docker.sock
+
+USER root
+
+RUN mkdir /home/node1
+
+USER jenkins
 
 RUN jenkins-plugin-cli --plugin-file=./jenkins/plugins.yml

--- a/doc/Build_base_images.md
+++ b/doc/Build_base_images.md
@@ -1,0 +1,14 @@
+# Build base images
+
+Thoses jobs builds and push the base images on the defined registry (by default the registry is on port 5000).
+
+The goal of the base image is to have an image common to all the child images for the differents languages, to avoid using too much space and to avoid the need of pulling the image for every container that need to be created.
+
+To add a new base image:
+
+1. Create a new folder named as the language needed in images, for example : `images/rust`
+2. Create a Dockerfile named `Dockerfile.base` in the newly created folder
+3. Put the basic configuration you want to have when you will need that image for the child images
+4. Edit this line in `jenkins/job_dsl.groovy` by adding your language (only use lowercase letters and no spaces) : `def languages = [ "c", "your_new_language" ]`
+
+Now if you start again your instance you should see in the `Base images` folder in Jenkins the new job.

--- a/doc/How_to_use.md
+++ b/doc/How_to_use.md
@@ -4,4 +4,8 @@
 
 * Run `docker-compose -f ./jenkins/docker-compose.yml up --build`.
 * Open a web navigator and go to `localhost:8080` (by default).
-* Sign in with user `admin` password is set by a .env file located at the root of the repo (by default).
+* Sign in with user `admin`, the password is set by a .env file located at the root of the repo (by default).
+
+### Jobs
+
+[Base images](Build_base_images.md)

--- a/images/c/Dockerfile.base
+++ b/images/c/Dockerfile.base
@@ -1,0 +1,11 @@
+FROM gcc:11
+
+SHELL [ "/bin/sh", "-c" ]
+
+WORKDIR /app
+
+ONBUILD COPY . .
+
+ONBUILD RUN make fclean && make tests-run && make fclean
+
+ONBUILD RUN make && make clean && find -type f -name "src/*.c" -delete

--- a/jenkins/docker-compose.yml
+++ b/jenkins/docker-compose.yml
@@ -11,5 +11,15 @@ services:
             - USER_ADMIN_PASSWORD=${USER_ADMIN_PASSWORD}
         volumes:
             - ./jenkins.yml:/var/jenkins.yml
+            - /var/run/docker.sock:/var/run/docker.sock
         ports:
             - 8080:8080
+
+    registry:
+        container_name: registry
+        restart: always
+        image: registry:2
+        ports:
+            - 5000:5000
+        volumes:
+            - /path/data:/var/lib/registry

--- a/jenkins/jenkins.yml
+++ b/jenkins/jenkins.yml
@@ -28,10 +28,10 @@ jenkins:
 
   nodes:
     - permanent:
-        labelString: "Test"
+        labelString: "Build"
         mode: NORMAL
-        name: "test node"
-        remoteFS: "/var/jenkins"
+        name: "Build images node"
+        remoteFS: "/home/node1"
         launcher:
           jnlp:
             workDirSettings:
@@ -39,3 +39,6 @@ jenkins:
               failIfWorkDirIsMissing: false
               internalDir: "remoting"
               workDirPath: "/tmp"
+
+jobs:
+  - file: ./jenkins/job_dsl.groovy

--- a/jenkins/job_dsl.groovy
+++ b/jenkins/job_dsl.groovy
@@ -1,0 +1,23 @@
+def languages = [ "c" ]
+
+folder("Base images") {
+    description("Contain all the base images")
+}
+
+for (language in languages) {
+    freeStyleJob("Base images/" + language) {
+        description("Build the base image of " + language)
+        customWorkspace("/home/node1")
+        steps {
+            dockerBuildAndPublish {
+                dockerfileDirectory("/images/" + language + "/Dockerfile.base")
+                dockerRegistryURL("http://localhost:5000")
+                repositoryName(language + "-base-image")
+                forcePull(false)
+                createFingerprints(false)
+                forceTag(false)
+            }
+            shell("echo \"" + language + " base image built !\"")
+        }
+    }
+}

--- a/jenkins/plugins.yml
+++ b/jenkins/plugins.yml
@@ -26,6 +26,6 @@ plugins:
   - artifactId: conditional-buildstep
     source:
       version: latest
-  - artifactId: ssh-slaves
+  - artifactId: ssh
     source:
       version: latest


### PR DESCRIPTION
The Job can be run with any languages if the correct informations are passed

Closes #2

# Description

Create the registry to stores the bases images created locally to ensure security and privacy about the images.
The Base Images folder in Jenkins contain the jobs to build all the necessary images
Can create new jobs for base images just by following the instructions in the Build_images.md file

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [x] I have tested this code
- [x] I have added sufficient documentation in the code
